### PR TITLE
Feat : Detail 페이지 , AddToBe 페이지

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -3,12 +3,12 @@ import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey: 'AIzaSyBW9zssZOBZvJlTpNmdLUjlfcjTAWIMdsM',
-  authDomain: 'rn-todo-prac-7cf77.firebaseapp.com',
-  projectId: 'rn-todo-prac-7cf77',
-  storageBucket: 'rn-todo-prac-7cf77.appspot.com',
-  messagingSenderId: '47160925799',
-  appId: '1:47160925799:web:9f4e6b25d0b57d38433ec2',
+  apiKey: 'AIzaSyA97LT3VhVzUiomQe6-7kmVB-JxyRgX8Lc',
+  authDomain: 'react-native-produc.firebaseapp.com',
+  projectId: 'react-native-produc',
+  storageBucket: 'react-native-produc.appspot.com',
+  messagingSenderId: '944667587943',
+  appId: '1:944667587943:web:5de12d1cd420b7e14aebc2',
 };
 
 const app = initializeApp(firebaseConfig);

--- a/navigation/Stacks.jsx
+++ b/navigation/Stacks.jsx
@@ -12,14 +12,7 @@ const Stack = createNativeStackNavigator();
 const Stacks = ({ navigation: { goBack } }) => {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen
-        name="Login"
-        component={Login}
-        options={{
-          animation: 'fade',
-          gestureEnabled: false,
-        }}
-      />
+      <Stack.Screen name="Login" component={Login} />
       <Stack.Screen name="SignUp" component={SignUp} />
       <Stack.Screen name="Landing" component={Landing} />
       <Stack.Screen name="AddToBe" component={AddToBe} />

--- a/screen/AddToBe.jsx
+++ b/screen/AddToBe.jsx
@@ -1,17 +1,55 @@
 import styled from '@emotion/native';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { TextInput, TouchableOpacity } from 'react-native';
 import CustomButton from '../components/Common/CustomButton';
 import CustomInput from '../components/Common/CustomInput';
 import { CustomH1 } from '../components/Common/CustomText';
+import { authService } from '../firebase';
 
-const AddToBe = () => {
+const AddToBe = ({
+  route: {
+    params: { toBeDetail },
+  },
+}) => {
+  const [correctText, setCorrectText] = useState('');
+  const [typingText, setTypingText] = useState('');
+  const typingRef = useRef();
+
+  const handleChangeClick = () => {
+    if (typingText === correctText) {
+      alert('오늘도 꿈에 가까워지기 성공!');
+      // firebase에 오늘 날짜를 저장하는 함수를 추가해야 합니다.
+    }
+    if (typingText !== correctText) {
+      alert('문장을 똑같이 입력해주세요!');
+      typingRef.current.focus();
+    }
+  };
+
+  useEffect(() => {
+    setCorrectText(
+      `나 ${authService.currentUser.displayName}는 ${toBeDetail.tobetitle}이다.`
+    );
+  }, []);
+
   return (
     <AddToBeContainer>
-      <CustomH1>나 이순신은 전쟁천재다.</CustomH1>
+      <CustomH1>
+        <TextInput>{correctText}</TextInput>
+      </CustomH1>
+
       <AddToBeInputContainer>
-        <CustomInput width={320} placeholder="나 이순신은 전쟁천재다." />
+        <CustomInput
+          width={320}
+          placeholder={correctText}
+          ref={typingRef}
+          value={typingText}
+          onChangeText={setTypingText}
+        />
       </AddToBeInputContainer>
-      <CustomButton>변경하기</CustomButton>
+      <TouchableOpacity onPress={handleChangeClick}>
+        <CustomButton>변경하기</CustomButton>
+      </TouchableOpacity>
     </AddToBeContainer>
   );
 };

--- a/screen/Detail.jsx
+++ b/screen/Detail.jsx
@@ -1,12 +1,45 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as Progress from 'react-native-progress';
 import styled from '@emotion/native';
 import { CustomH2, CustomH3 } from '../components/Common/CustomText';
 import * as Animatable from 'react-native-animatable';
+import CustomButton from '../components/Common/CustomButton';
+import { TouchableOpacity } from 'react-native';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
 
-const Detail = () => {
+const Detail = ({
+  navigation: { navigate },
+  route: {
+    params: { id },
+  },
+}) => {
   // completed는 나중에 확언 리스트의 개수만큼 카운트수가 저장되도록 세팅
   const completed = 18;
+  const [toBeDetail, setToBeDetail] = useState({});
+
+  const getDetail = async () => {
+    const docRef = doc(db, 'Tobelist', id);
+    const docSnap = await getDoc(docRef);
+    console.log('docSnap:', docSnap);
+    setToBeDetail({
+      id: docSnap.id,
+      ...docSnap.data(),
+    });
+  };
+
+  useEffect(() => {
+    getDetail();
+    console.log('toBeDetail:', toBeDetail);
+  }, []);
+
+  const handleAddClick = () => {
+    navigate('Stacks', {
+      screen: 'AddToBe',
+      params: { toBeDetail },
+    });
+  };
+
   return (
     <DetailContainer>
       <TopStatusView>
@@ -68,7 +101,9 @@ const Detail = () => {
         </DetailListText>
       </DetailListScroll>
 
-      {/* 이 부분에 버튼 들어올거에유 */}
+      <TouchableOpacity onPress={handleAddClick}>
+        <CustomButton>추가하기</CustomButton>
+      </TouchableOpacity>
     </DetailContainer>
   );
 };

--- a/screen/Landing.jsx
+++ b/screen/Landing.jsx
@@ -3,7 +3,7 @@ import { CustomH1 } from '../components/Common/CustomText';
 import { getAuth } from 'firebase/auth';
 import styled from '@emotion/native';
 
-const Landing = () => {
+const Landing = ({ navigation: { reset } }) => {
   const [userName, setUserName] = useState('');
 
   const auth = getAuth();
@@ -12,6 +12,15 @@ const Landing = () => {
     const user = auth?.currentUser;
     setUserName(user?.displayName);
   }, []);
+
+  useEffect(() => {
+    setTimeout(() => {
+      //푸슝푸슝 이슈
+      reset({
+        routes: [{ name: 'Tabs', params: { screen: 'Main' } }],
+      });
+    }, 2000);
+  }, [userName]);
 
   return (
     <LandingContainer>

--- a/screen/Login.jsx
+++ b/screen/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import styled from '@emotion/native';
 import ThereAreMainText from '../components/Common/ThereAreMainText';
 import CustomInput from '../components/Common/CustomInput';
@@ -14,6 +14,10 @@ const Login = ({ navigation: { navigate } }) => {
   const pwRef = useRef(null);
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
+
+  useEffect(() => {
+    authService.currentUser ? navigate('Stacks', { screen: 'Landing' }) : null;
+  }, []);
 
   // 유효성 검사
   const validateInputs = () => {
@@ -56,7 +60,7 @@ const Login = ({ navigation: { navigate } }) => {
         setEmail('');
         setPw('');
         // 로그인 성공시 임시로 Detail로 가도록 로직을 걸어놓았습니다.
-        navigate('Tabs', { screen: 'Main' });
+        navigate('Stacks', { screen: 'Landing' });
       })
       .catch((err) => {
         console.log('err.message:', err.message);

--- a/screen/Main.jsx
+++ b/screen/Main.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/native';
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import CustomButton from '../components/Common/CustomButton';
 import { CustomH1 } from '../components/Common/CustomText';
 import { getAuth } from 'firebase/auth';
@@ -13,14 +13,28 @@ const Main = ({ navigation: { navigate } }) => {
     const user = auth?.currentUser;
     setUserName(user?.displayName);
   }, []);
+
+  const handleAddPress = () => {
+    navigate('Stacks', { screen: 'AddDetail' });
+  };
+
+  const handleDetailPress = () => {
+    navigate('Stacks', {
+      screen: 'Detail',
+      params: { id: 'tVR0Gn3TaiUFkjdtba5c' },
+    });
+  };
+
+  // tVR0Gn3TaiUFkjdtba5c
+
   return (
     <MainContainer>
       <ListedContainer>
-        <ListedText>나 {userName}은 전쟁천재이다.</ListedText>
-        <ListedText>나 {userName}은 기록 장인이다.</ListedText>
-        <ListedText>나 {userName}은 애국자다.</ListedText>
+        <TouchableOpacity onPress={handleDetailPress}>
+          <ListedText>나 {userName}은 전쟁천재이다.</ListedText>
+        </TouchableOpacity>
       </ListedContainer>
-      <ButtonContainer>
+      <ButtonContainer onPress={handleAddPress}>
         <CustomButton>추가하기</CustomButton>
       </ButtonContainer>
     </MainContainer>
@@ -36,7 +50,7 @@ const ListedContainer = styled.View`
   margin-top: 250px;
 `;
 
-const ButtonContainer = styled.View`
+const ButtonContainer = styled.TouchableOpacity`
   align-items: center;
   justify-content: center;
   margin-top: 150px;

--- a/screen/SignUp.jsx
+++ b/screen/SignUp.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import styled from '@emotion/native';
 import ThereAreMainText from '../components/Common/ThereAreMainText';
 import CustomInput from '../components/Common/CustomInput';
@@ -15,6 +15,9 @@ const SignUp = ({ navigation: { navigate } }) => {
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
   const [userNickName, setUserNickName] = useState('');
+  useEffect(() => {
+    authService.currentUser ? navigate('Stacks', { screen: 'Landing' }) : null;
+  }, []);
 
   //유효성 검사
   const validateInputs = () => {

--- a/screen/Splash.jsx
+++ b/screen/Splash.jsx
@@ -4,16 +4,16 @@ import { CustomSplashTitle } from '../components/Common/CustomText';
 import { useQuery } from 'react-query';
 import { getFamousSaying } from '../api';
 import { ActivityIndicator } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
 
 const Splash = ({ navigation: { reset } }) => {
   const [saying, setSaying] = useState('');
 
-  useFocusEffect(() => {
-    setTimeout(() => {
-      reset({ routes: [{ name: 'Stacks', params: { screen: 'Login' } }] });
-    }, 3000);
-  });
+  setTimeout(() => {
+    //푸슝푸슝 이슈
+    reset({
+      routes: [{ name: 'Stacks', params: { screen: 'Login' } }],
+    });
+  }, 3000);
 
   // useMemo ?? 어떤 값을 가져오기 위한거(특정 데이터 저장하려고)
   // useEffect ?? 어떤 함수, 로직을 실행할때


### PR DESCRIPTION
* Main 페이지 :
  - Detail페이지로 이동 (특정글 클릭시 id 함께 전달)

* SingUp / Login 페이지 :
  - auth.currentUser 데이터가 있을시 Landing페이지로 이동하도록 로직 작성

* Detail페이지 :
   - 추가하기 버튼 생성
   - 추가하기 버튼 클릭시 AddToBe 페이지 이동 (AddToBe페이지에 toBeDetail 데이터 함께 전달)
   - Main페이지에서 전달받은 id로 특정게시물을 조회해오는 로직 작성

* AddToBe페이지 :
  - Detail페이지에서 전달받은 toBeDetail를 화면에 구성
  - 유저가 input 입력시 toBeDetail과 일치하도록 유효성 검사 로직 작성

by Jeremy-kr , ddoqi